### PR TITLE
Fix pluginsync

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,5 +6,6 @@
   "project_page": "https://github.com/cannonps/local_group_policy",
   "source": "https://github.com/cannonps/local_group_policy",
   "summary": "Local Group Policy Editor",
-  "version": "1.0.1"
+  "version": "1.0.1",
+  "dependencies": [ ]
 }


### PR DESCRIPTION
The metadata.json was missing the dependency array, which prevented
puppetserver from syncing the lib directory to the agent.

Signed-off-by: Samuli Seppänen <samuli.seppanen@gmail.com>